### PR TITLE
Make sure that the menu view is always in front

### DIFF
--- a/Library/ENSideMenu.swift
+++ b/Library/ENSideMenu.swift
@@ -166,6 +166,7 @@ class ENSideMenu : NSObject {
     
     private func toggleMenu (shouldOpen: Bool) {
         isMenuOpen = shouldOpen
+        sourceView.bringSubviewToFront(sideMenuContainerView)
         if (bouncingEnabled) {
             
             animator.removeAllBehaviors()


### PR DESCRIPTION
Make sure that the menu view is always in front of other subviews of contentViewController
or else it may hide behind them. 
I experienced this problem while using a contentViewController which was not a UINavigationcontroller subclass and using the UIViewController containment APIs to add child viewcontrollers to it.
