### PR TITLE
Fixed 'Expected type after as'

### DIFF
--- a/Library/ENSideMenu.swift
+++ b/Library/ENSideMenu.swift
@@ -248,7 +248,7 @@ public class ENSideMenu : NSObject, UIGestureRecognizerDelegate {
     
     public func gestureRecognizerShouldBegin(gestureRecognizer: UIGestureRecognizer) -> Bool {
         if gestureRecognizer is UISwipeGestureRecognizer {
-            let swipeGestureRecognizer = gestureRecognizer as! UISwipeGestureRecognizer
+            let swipeGestureRecognizer = gestureRecognizer as UISwipeGestureRecognizer
             if !self.allowLeftSwipe {
                 if swipeGestureRecognizer.direction == .Left {
                     return false


### PR DESCRIPTION
I've had problems with ENSideMenu.swift,
where it gives the "Expected type after 'as'" error,
and am hoping this will fix it for some.

I'm using Xcode 6.2.

Thanks!