### PR TITLE
Fix wrong parameter name in example code

### DIFF
--- a/Example/SwiftSideMenu/MyNavigationController.swift
+++ b/Example/SwiftSideMenu/MyNavigationController.swift
@@ -13,7 +13,7 @@ class MyNavigationController: ENSideMenuNavigationController, ENSideMenuDelegate
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        sideMenu = ENSideMenu(sourceView: self.view, menuTableViewController: MyMenuTableViewController(), menuPosition:.Left)
+        sideMenu = ENSideMenu(sourceView: self.view, menuViewController: MyMenuTableViewController(), menuPosition:.Left)
         //sideMenu?.delegate = self //optional
         sideMenu?.menuWidth = 180.0 // optional, default is 160
         //sideMenu?.bouncingEnabled = false


### PR DESCRIPTION
The example code did not compile due to a wrongly named parameter. This patch should do the job.