### PR TITLE
improved topMostController() function

### DIFF
--- a/Library/ENSideMenu.swift
+++ b/Library/ENSideMenu.swift
@@ -105,11 +105,15 @@ public extension UIViewController {
         if (topController is UITabBarController) {
             topController = (topController as! UITabBarController).selectedViewController
         }
-        while (topController?.presentedViewController is ENSideMenuProtocol) {
+        var lastMenuProtocol : ENSideMenuProtocol?
+        while (topController?.presentedViewController != nil) {
+            if(topController?.presentedViewController is ENSideMenuProtocol) {
+                lastMenuProtocol = topController?.presentedViewController as? ENSideMenuProtocol
+            }
             topController = topController?.presentedViewController
         }
         
-        return topController as? ENSideMenuProtocol
+        return lastMenuProtocol
     }
 }
 


### PR DESCRIPTION
Fixes the bug: `topMostController()` returns *null* if the second presented view controller after the root controller is **NOT** `ENSideMenuProtocol` even though there may be such view controllers in the stack.

Expected behavior: It should return the foremost menu protocol (`ENSideMenuProtocol`)

Say you have the following view controller stack
RootVC->VC1->VC2->MenuVC

In the current code, `topMostController()` would **NOT** return the MenuVC because VC1 is not a `ENSideMenuProtocol`. This improvement fixes the bug. Thus, MenuVC is returned no matter what the formation or order of view controllers in the stack is.