### PR TITLE
add default implementations for menu event methods

### DIFF
--- a/Library/ENSideMenu.swift
+++ b/Library/ENSideMenu.swift
@@ -16,6 +16,13 @@ public protocol ENSideMenuDelegate: class {
     func sideMenuDidClose()
 }
 
+extension ENSideMenuDelegate {
+    func sideMenuWillOpen() {}
+    func sideMenuWillClose() {}
+    func sideMenuDidOpen() {}
+    func sideMenuDidClose() {}
+}
+
 public protocol ENSideMenuProtocol: class {
     var sideMenu : ENSideMenu? { get }
     func setContentViewController(_ contentViewController: UIViewController)


### PR DESCRIPTION
by adding default implementations inside a protocol extension of ENSideMenuDelegate, the methods become optional without the need to add @objc.
no downsides as far as I can see.